### PR TITLE
feat: implement key template registry and builder with tests

### DIFF
--- a/pkg/key/registry.go
+++ b/pkg/key/registry.go
@@ -1,0 +1,42 @@
+package key
+
+import "fmt"
+
+// globalRegistry is a package-level registry for shared templates.
+var globalRegistry = NewRegistry()
+
+// GlobalRegistry returns the package-level registry instance.
+func GlobalRegistry() *Registry {
+	return globalRegistry
+}
+
+// Registry stores named key templates for reuse.
+type Registry struct {
+	templates map[string]*TemplateKeyBuilder
+}
+
+// NewRegistry creates a new empty registry.
+func NewRegistry() *Registry {
+	return &Registry{templates: make(map[string]*TemplateKeyBuilder)}
+}
+
+// Register adds a named template if it does not already exist.
+// Returns an error if the name is already registered.
+func (r *Registry) Register(name string, tmpl *TemplateKeyBuilder) error {
+	if _, exists := r.templates[name]; exists {
+		return fmt.Errorf("template with name '%s' already exists", name)
+	}
+	r.templates[name] = tmpl
+	return nil
+}
+
+// Get retrieves a named template builder.
+func (r *Registry) Get(name string) (*TemplateKeyBuilder, bool) {
+	t, ok := r.templates[name]
+	return t, ok
+}
+
+// Delete removes a named template.
+func (r *Registry) Delete(name string) {
+	delete(r.templates, name)
+}

--- a/pkg/key/registry_test.go
+++ b/pkg/key/registry_test.go
@@ -1,0 +1,73 @@
+package key
+
+import (
+	"testing"
+)
+
+func TestRegistry_RegisterAndGet(t *testing.T) {
+	r := NewRegistry()
+	tmpl, err := Template("foo:{bar}")
+	if err != nil {
+		t.Fatalf("unexpected error on Template: %v", err)
+	}
+	err = r.Register("foo", tmpl)
+	if err != nil {
+		t.Fatalf("unexpected error on Register: %v", err)
+	}
+	b, ok := r.Get("foo")
+	if !ok {
+		t.Fatal("expected template to be found")
+	}
+	key, err := b.Build(nil, map[string]interface{}{"bar": 123})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "foo:123" {
+		t.Errorf("got %q, want %q", key, "foo:123")
+	}
+}
+
+func TestRegistry_Delete(t *testing.T) {
+	r := NewRegistry()
+	tmpl, err := Template("foo:{bar}")
+	if err != nil {
+		t.Fatalf("unexpected error on Template: %v", err)
+	}
+	err = r.Register("foo", tmpl)
+	if err != nil {
+		t.Fatalf("unexpected error on Register: %v", err)
+	}
+	r.Delete("foo")
+	_, ok := r.Get("foo")
+	if ok {
+		t.Fatal("expected template to be deleted")
+	}
+}
+
+func TestGlobalRegistry(t *testing.T) {
+	tmpl, err := Template("user:{id}")
+	if err != nil {
+		t.Fatalf("unexpected error on Template: %v", err)
+	}
+	err = GlobalRegistry().Register("user", tmpl)
+	if err != nil {
+		t.Fatalf("unexpected error on Register: %v", err)
+	}
+	b, ok := GlobalRegistry().Get("user")
+	if !ok {
+		t.Fatal("expected global template to be found")
+	}
+	key, err := b.Build(nil, map[string]interface{}{"id": 42})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "user:42" {
+		t.Errorf("got %q, want %q", key, "user:42")
+	}
+	GlobalRegistry().Delete("user")
+
+	_, ok = GlobalRegistry().Get("user")
+	if ok {
+		t.Fatal("expected global template to be deleted")
+	}
+}

--- a/pkg/key/template.go
+++ b/pkg/key/template.go
@@ -1,0 +1,123 @@
+package key
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+// TemplateKeyBuilder is a KeyBuilder implementation that builds a key from a template string.
+//
+// Example:
+//
+//	builder := &TemplateKeyBuilder{Template: "user:{userID}:data:{dataID}"}
+//	key, _ := builder.Build(ctx, map[string]any{"userID": 42, "dataID": "abc"}) // key == "user:42:data:abc"
+//
+// Useful for readable, structured keys.
+// KeyVars is an optional interface for custom structs to provide template variables.
+type KeyVars interface { //nolint:revive
+	KeyVars() map[string]interface{}
+}
+
+// TemplateKeyBuilder builds keys from a template string.
+type TemplateKeyBuilder struct {
+	Template string
+}
+
+func Template(tmpl string) (*TemplateKeyBuilder, error) {
+	// Basic validation: must not be empty, braces must be balanced, fields must be non-empty, and only allowed characters
+	if len(tmpl) == 0 {
+		return nil, fmt.Errorf("template string cannot be empty")
+	}
+	allowedRegex := regexp.MustCompile(`^[a-zA-Z0-9/_|:\-{}]+$`)
+	if !allowedRegex.MatchString(tmpl) {
+		return nil, fmt.Errorf("template contains invalid characters. Allowed: a-z, A-Z, 0-9, /, |, -, _, :, {}")
+	}
+	fieldRegex := regexp.MustCompile(`^[a-zA-Z0-9/_|:\-]+$`)
+	for i := 0; i < len(tmpl); i++ {
+		if tmpl[i] == '{' {
+			j := strings.IndexByte(tmpl[i:], '}')
+			if j == -1 {
+				return nil, fmt.Errorf("template contains unclosed '{'")
+			}
+			j += i
+			if j == i+1 {
+				return nil, fmt.Errorf("template contains empty field name: {}")
+			}
+			field := tmpl[i+1 : j]
+			if !fieldRegex.MatchString(field) {
+				return nil, fmt.Errorf("template field contains invalid characters in {%s}. Allowed: a-z, A-Z, 0-9", field)
+			}
+			i = j
+		}
+	}
+	return &TemplateKeyBuilder{Template: tmpl}, nil
+}
+
+// Build replaces {field} in the template using data from map, struct, or KeyVars interface.
+//
+// Data source priority (highest to lowest):
+//  1. If data implements KeyVars, uses KeyVars() map.
+//  2. If data is map[string]interface{}, uses map values.
+//  3. If data is a struct, uses exported struct fields.
+//
+// Returns an error if any template fields are missing.
+func (t *TemplateKeyBuilder) Build(ctx context.Context, data any) (string, error) { //nolint:cyclop
+	vars := make(map[string]interface{})
+	switch v := data.(type) {
+	case KeyVars:
+		vars = v.KeyVars()
+	case map[string]interface{}:
+		vars = v
+	default:
+		rv := reflect.ValueOf(data)
+		if rv.Kind() == reflect.Ptr {
+			rv = rv.Elem()
+		}
+		if rv.Kind() == reflect.Struct {
+			rt := rv.Type()
+			for i := 0; i < rt.NumField(); i++ {
+				f := rt.Field(i)
+				if f.PkgPath == "" { // exported
+					vars[f.Name] = rv.Field(i).Interface()
+				}
+			}
+		}
+	}
+
+	key := t.Template
+	missing := []string{}
+	result := ""
+	start := 0
+	for {
+		i := strings.Index(key[start:], "{")
+		if i == -1 {
+			result += key[start:]
+			break
+		}
+		i += start
+		result += key[start:i]
+		j := strings.Index(key[i:], "}")
+		if j == -1 {
+			// Unclosed brace, treat as literal
+			result += key[i:]
+			break
+		}
+		j += i
+		field := key[i+1 : j]
+		val, ok := vars[field]
+		if ok {
+			result += fmt.Sprintf("%v", val)
+		} else {
+			missing = append(missing, field)
+			result += "{" + field + "}"
+		}
+		start = j + 1
+	}
+	if len(missing) > 0 {
+		return "", fmt.Errorf("missing template fields: %v", missing)
+	}
+	return result, nil
+}

--- a/pkg/key/template_test.go
+++ b/pkg/key/template_test.go
@@ -1,0 +1,188 @@
+package key
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTemplateKeyBuilder_FieldDelimiters(t *testing.T) {
+	cases := []struct {
+		template string
+		data     map[string]interface{}
+		want     string
+	}{
+		{"foo:{foo-bar}", map[string]interface{}{"foo-bar": "A"}, "foo:A"},
+		{"foo:{foo_bar}", map[string]interface{}{"foo_bar": "B"}, "foo:B"},
+		{"foo:{foo/bar}", map[string]interface{}{"foo/bar": "C"}, "foo:C"},
+		{"foo:{foo|bar}", map[string]interface{}{"foo|bar": "D"}, "foo:D"},
+		{"foo:{foo:bar}", map[string]interface{}{"foo:bar": "E"}, "foo:E"},
+	}
+	for _, tc := range cases {
+		builder, err := Template(tc.template)
+		if err != nil {
+			t.Fatalf("unexpected error for template %q: %v", tc.template, err)
+		}
+		key, err := builder.Build(context.Background(), tc.data)
+		if err != nil {
+			t.Fatalf("unexpected error for Build on template %q: %v", tc.template, err)
+		}
+		if key != tc.want {
+			t.Errorf("template %q: got %q, want %q", tc.template, key, tc.want)
+		}
+	}
+}
+
+func TestTemplateKeyBuilder_Map(t *testing.T) {
+	builder, err := Template("user:{userID}:data:{dataID}")
+	if err != nil {
+		t.Fatalf("unexpected error for template: %v", err)
+	}
+	key, err := builder.Build(context.Background(), map[string]interface{}{"userID": 42, "dataID": "abc"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "user:42:data:abc" {
+		t.Errorf("got %q, want %q", key, "user:42:data:abc")
+	}
+}
+
+func TestTemplateKeyBuilder_Struct(t *testing.T) {
+	type User struct {
+		ID   int
+		Name string
+	}
+	builder, err := Template("user:{ID}:name:{Name}")
+	if err != nil {
+		t.Fatalf("unexpected error for template: %v", err)
+	}
+	key, err := builder.Build(context.Background(), User{ID: 7, Name: "alice"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "user:7:name:alice" {
+		t.Errorf("got %q, want %q", key, "user:7:name:alice")
+	}
+}
+
+type Session struct {
+	UserID    string
+	SessionID string
+}
+
+func (s Session) KeyVars() map[string]interface{} {
+	return map[string]interface{}{"userID": s.UserID, "sessionID": s.SessionID}
+}
+
+func TestTemplateKeyBuilder_KeyVars(t *testing.T) {
+	builder, err := Template("session:{userID}:{sessionID}")
+	if err != nil {
+		t.Fatalf("unexpected error for template: %v", err)
+	}
+	key, err := builder.Build(context.Background(), Session{UserID: "bob", SessionID: "xyz"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "session:bob:xyz" {
+		t.Errorf("got %q, want %q", key, "session:bob:xyz")
+	}
+}
+
+func TestTemplateKeyBuilder_MissingFields(t *testing.T) {
+	builder, err := Template("user:{userID}:data:{dataID}")
+	if err != nil {
+		t.Fatalf("unexpected error for template: %v", err)
+	}
+	_, err = builder.Build(context.Background(), map[string]interface{}{"userID": 42})
+	if err == nil {
+		t.Fatal("expected error for missing field")
+	}
+	if got, want := err.Error(), "missing template fields: [dataID]"; got != want {
+		t.Errorf("got error %q, want %q", got, want)
+	}
+}
+
+func TestTemplateKeyBuilder_PointerStruct(t *testing.T) {
+	type User struct {
+		ID   int
+		Name string
+	}
+	builder, err := Template("user:{ID}:name:{Name}")
+	if err != nil {
+		t.Fatalf("unexpected error for template: %v", err)
+	}
+	user := &User{ID: 99, Name: "bob"}
+	key, err := builder.Build(context.Background(), user)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "user:99:name:bob" {
+		t.Errorf("got %q, want %q", key, "user:99:name:bob")
+	}
+}
+
+func TestTemplateKeyBuilder_EmptyTemplate(t *testing.T) {
+	_, err := Template("")
+	if err == nil {
+		t.Fatal("expected error for empty template, got nil")
+	}
+}
+
+func TestTemplateKeyBuilder_ExtraFields(t *testing.T) {
+	builder, err := Template("user:{userID}")
+	if err != nil {
+		t.Fatalf("unexpected error for template: %v", err)
+	}
+	key, err := builder.Build(context.Background(), map[string]interface{}{"userID": 1, "extra": 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "user:1" {
+		t.Errorf("got %q, want %q", key, "user:1")
+	}
+}
+
+func TestTemplateKeyBuilder_FieldTypes(t *testing.T) {
+	builder, err := Template("foo:{int}:{str}:{bool}")
+	if err != nil {
+		t.Fatalf("unexpected error for template: %v", err)
+	}
+	key, err := builder.Build(context.Background(), map[string]interface{}{"int": 1, "str": "x", "bool": true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "foo:1:x:true" {
+		t.Errorf("got %q, want %q", key, "foo:1:x:true")
+	}
+}
+
+func TestTemplateKeyBuilder_ContextIgnored(t *testing.T) {
+	builder, err := Template("static")
+	if err != nil {
+		t.Fatalf("unexpected error for template: %v", err)
+	}
+	key, err := builder.Build(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "static" {
+		t.Errorf("got %q, want %q", key, "static")
+	}
+}
+
+func TestTemplateKeyBuilder_ReflectUnexported(t *testing.T) {
+	type hidden struct {
+		Visible string
+		secret  string
+	}
+	builder, err := Template("{Visible}")
+	if err != nil {
+		t.Fatalf("unexpected error for template: %v", err)
+	}
+	key, err := builder.Build(context.Background(), hidden{Visible: "ok", secret: "nope"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "ok" {
+		t.Errorf("got %q, want %q", key, "ok")
+	}
+}

--- a/scripts/merge_coverage.go
+++ b/scripts/merge_coverage.go
@@ -46,7 +46,7 @@ func main() { //nolint:cyclop
 				if mode == "" {
 					mode = m
 				} else if mode != m {
-					log.Fatalf("coverage mode mismatch: %s vs %s (file %s)", mode, m, p) //nolint:gocritic
+					log.Fatalf("coverage mode mismatch: %s vs %s (file %s)", mode, m, p)
 				}
 				continue
 			}
@@ -83,7 +83,7 @@ func main() { //nolint:cyclop
 	defer out.Close()
 
 	if mode == "" {
-		log.Fatalf("no mode found in inputs")
+		log.Fatalf("no mode found in inputs") //nolint:gocritic
 	}
 	fmt.Fprintf(out, "mode: %s\n", mode)
 


### PR DESCRIPTION
This pull request introduces a new template-based key builder utility for generating structured keys, along with a registry for managing reusable key templates. It provides a flexible way to build keys from template strings using maps, structs, or custom types, and includes comprehensive unit tests to ensure correct behavior.

Key builder implementation:

* Added `TemplateKeyBuilder` in `pkg/key/template.go`, which builds keys from template strings using data provided as a map, struct, or type implementing the `KeyVars` interface. Includes validation for template syntax and error reporting for missing fields.

Registry for template builders:

* Introduced a package-level `Registry` in `pkg/key/registry.go`, allowing registration, retrieval, and deletion of named key templates. Also provides a singleton `GlobalRegistry` for shared templates.

Unit tests:

* Added tests in `pkg/key/template_test.go` covering template parsing, key generation from maps, structs, and custom types, error handling for missing fields, pointer support, extra fields, type handling, and ignoring context.
* Added tests in `pkg/key/registry_test.go` for registry operations, including registering, retrieving, and deleting templates, as well as using the global registry.