### PR TITLE
feat: add options parameter to Get and Set methods in Client

### DIFF
--- a/pkg/client/backend.go
+++ b/pkg/client/backend.go
@@ -79,9 +79,13 @@ func (c Client) MatchKeys(ctx context.Context, prefix string, f MatchKeysFunc) (
 //
 //	var value string
 //	err := client.Get(ctx, "myKey", &value)
-func (c Client) Get(ctx context.Context, key string, value any) error {
+func (c Client) Get(ctx context.Context, key string, value any, opts ...Options) error {
 	if key == "" {
 		return errs.ErrEmptyKey
+	}
+
+	for _, opt := range opts {
+		opt(c.opts)
 	}
 
 	vV, err := c.GetRaw(ctx, key)
@@ -98,9 +102,13 @@ func (c Client) Get(ctx context.Context, key string, value any) error {
 // Example:
 //
 //	err := client.Set(ctx, "myKey", "myValue")
-func (c Client) Set(ctx context.Context, key string, value any) error {
+func (c Client) Set(ctx context.Context, key string, value any, opts ...Options) error {
 	if key == "" {
 		return errs.ErrEmptyKey
+	}
+
+	for _, opt := range opts {
+		opt(c.opts)
 	}
 
 	vV, err := c.opts.Encoder.Encode(ctx, value)

--- a/pkg/errs/errs.go
+++ b/pkg/errs/errs.go
@@ -10,6 +10,7 @@ var (
 	ErrEmptyFunc             = errors.New("function is nil")
 	ErrClientNotInitialized  = errors.New("client is not initialized")
 	ErrEmptyBatch            = errors.New("empty batch provided")
+	ErrEmptyEncoder          = errors.New("encoder is nil")
 )
 
 var ErrHealthCheckFailed = func(err error) error {


### PR DESCRIPTION
This pull request introduces improvements to the client API in `pkg/client/backend.go` and adds a new error type in `pkg/errs/errs.go`. The main focus is on enhancing the flexibility of the `Get` and `Set` methods by allowing additional options to be passed, and improving error handling for encoder-related issues.

Enhancements to client API:

* Updated the signatures of the `Get` and `Set` methods in the `Client` type to accept variadic `Options`, allowing callers to customize behavior with additional options. The methods now apply these options before performing their main operations. (`pkg/client/backend.go`) [[1]](diffhunk://#diff-176e82d7405d378e1f43397f7df5a38473928cd146658bdb7d6e50a776525a50L82-R90) [[2]](diffhunk://#diff-176e82d7405d378e1f43397f7df5a38473928cd146658bdb7d6e50a776525a50L101-R113)

Error handling improvements:

* Added a new error variable `ErrEmptyEncoder` to handle cases where an encoder is not provided. (`pkg/errs/errs.go`)