### PR TITLE
feat: add template in key builder

### DIFF
--- a/pkg/key/registry.go
+++ b/pkg/key/registry.go
@@ -1,6 +1,9 @@
 package key
 
-import "fmt"
+import (
+	"fmt"
+	"sync"
+)
 
 // globalRegistry is a package-level registry for shared templates.
 var globalRegistry = NewRegistry()
@@ -12,31 +15,69 @@ func GlobalRegistry() *Registry {
 
 // Registry stores named key templates for reuse.
 type Registry struct {
+	mu        sync.RWMutex
 	templates map[string]*TemplateKeyBuilder
+	funcs     map[string]TransformFunc // registry-level functions
 }
 
 // NewRegistry creates a new empty registry.
 func NewRegistry() *Registry {
-	return &Registry{templates: make(map[string]*TemplateKeyBuilder)}
+	return &Registry{
+		templates: make(map[string]*TemplateKeyBuilder),
+		funcs:     make(map[string]TransformFunc),
+	}
 }
 
-// Register adds a named template if it does not already exist.
-// Returns an error if the name is already registered.
+// Register adds a named template and injects all registry-level functions into it.
 func (r *Registry) Register(name string, tmpl *TemplateKeyBuilder) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if _, exists := r.templates[name]; exists {
 		return fmt.Errorf("template with name '%s' already exists", name)
+	}
+	// Inject all registry-level funcs into the template
+	for fname, fn := range r.funcs {
+		tmpl.RegisterFunc(fname, fn)
 	}
 	r.templates[name] = tmpl
 	return nil
 }
 
+// RegisterFunc registers a transformation function globally for all templates in the registry.
+func (r *Registry) RegisterFunc(name string, fn TransformFunc) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.funcs[name] = fn
+	// Inject into all existing templates
+	for _, tmpl := range r.templates {
+		tmpl.RegisterFunc(name, fn)
+	}
+}
+
 // Get retrieves a named template builder.
 func (r *Registry) Get(name string) (*TemplateKeyBuilder, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	t, ok := r.templates[name]
 	return t, ok
 }
 
+// MustGet retrieves a named template builder or panics if not found.
+func (r *Registry) MustGet(name string) *TemplateKeyBuilder {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	t, ok := r.templates[name]
+	if !ok {
+		panic(fmt.Sprintf("template with name '%s' not found", name))
+	}
+	return t
+}
+
 // Delete removes a named template.
 func (r *Registry) Delete(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	delete(r.templates, name)
 }


### PR DESCRIPTION
This pull request introduces major enhancements to the template-based key builder system, adding support for variable transformations, custom functions, and conditional logic in key templates. The changes make key templates much more flexible and expressive, allowing for built-in and user-defined transformations, thread-safe registry management, and improved error handling. Several new unit tests have been added to verify the new features.

### Template engine enhancements

* Added support for transformation functions in `TemplateKeyBuilder`, allowing template variables to be transformed using built-in functions (e.g., `upper`, `lower`, `default`, `slugify`, `if`, `intadd`) and custom user-defined functions. Tokens in templates can now use the syntax `{field|func1|func2(args)}` for advanced key generation. [[1]](diffhunk://#diff-acb128ad51fb31c8cfb55ba2f81691e0003dbc6e28a6aeb38d3a5acdac94d7faR8-R51) [[2]](diffhunk://#diff-acb128ad51fb31c8cfb55ba2f81691e0003dbc6e28a6aeb38d3a5acdac94d7faL83-R197)
* Improved error handling for unknown transformation functions and missing fields, with built-in support for default values and conditionals to avoid errors when fields are missing. [[1]](diffhunk://#diff-acb128ad51fb31c8cfb55ba2f81691e0003dbc6e28a6aeb38d3a5acdac94d7faL83-R197) [[2]](diffhunk://#diff-7e9c804f7fc23debebe7d542303dc14dff3efd630d675c652eb007dad1eb4a53L91-R182)

### Registry and thread safety

* Refactored `Registry` to support thread-safe operations using a mutex, and added global registration of transformation functions that are injected into all templates in the registry. [[1]](diffhunk://#diff-13c703c3ca6b058c52bd8970f8dae9ac1083aa847c05971a321689e21011dcf0L3-R6) [[2]](diffhunk://#diff-13c703c3ca6b058c52bd8970f8dae9ac1083aa847c05971a321689e21011dcf0R18-R83)

### Testing and validation

* Added comprehensive unit tests for transformation functions, custom function registration, error handling, and field delimiters to ensure correctness and robustness of the new features. [[1]](diffhunk://#diff-7e9c804f7fc23debebe7d542303dc14dff3efd630d675c652eb007dad1eb4a53R5-R107) [[2]](diffhunk://#diff-7e9c804f7fc23debebe7d542303dc14dff3efd630d675c652eb007dad1eb4a53L91-R182)